### PR TITLE
docs(rules/reqScript): 修正文档错别字

### DIFF
--- a/docs/zh/rules/reqScript.md
+++ b/docs/zh/rules/reqScript.md
@@ -17,7 +17,7 @@ whistle判断如果文件的第一行为规则的注释，即`#`开头，则任�
 	patternN operatorURIN
 
 ### 通过脚本动态设置规则
-rulesFile可以指定一个脚本，whistle在执行脚本时会自动在全局传人：
+rulesFile可以指定一个脚本，whistle在执行脚本时会自动在全局传入：
 
 1. `url`: 请求的完整路径
 2. `method`: 请求方法


### PR DESCRIPTION
文档链接：http://wproxy.org/whistle/rules/reqScript.html#通过脚本动态设置规则

修正内容：`全局传人` -> `全局传入`

![image](https://user-images.githubusercontent.com/20762680/57993566-23065980-7aec-11e9-8b3c-b10cc71017fd.png)
