### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM alpine
+COPY .npmrc /root/
+RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories&&apk add --no-cache nodejs npm && npm install whistle -g && apk del npm && mkdir /whistle
+CMD w2 run -D /whistle
+EXPOSE 8899


### PR DESCRIPTION
添加了对 Docker 的支持。镜像的尺寸为 68.4MB 。其中：

```
RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories
```

是国内构建镜像用到的，如果在 docker hub 上开启了自动构建的话就无需这个了。

平时我是配合 docker-compose 使用的，但是因为这个仓库貌似还没有官方镜像，所以没有提交 docker-compose.yml 。compose 文件内容如下：

```
version: "3.9"

services:
  whistle:
    build: .
    ports:
      - 8899:8899
    restart: unless-stopped
    environment:
      WHISTLE_PATH: "/whistle"
    volumes:
      - whistle_data:/whistle

volumes:
  whistle_data: {}
```