### PR TITLE
fix: 删除 ADD 指令，使用 w2 run -M prod -D /whistle, 不再换源

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
-COPY .npmrc /root/
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories&&apk add --no-cache nodejs npm && npm install whistle -g && apk del npm && mkdir /whistle
-CMD w2 run -M prod -D /whistle
 EXPOSE 8899
+RUN apk add --no-cache nodejs npm \
+    && npm install whistle -g \
+    && apk del npm \
+    && mkdir /whistle
+ENTRYPOINT ["w2", "run", "-M","prod", "-D","/whistle"]


### PR DESCRIPTION
删除了上次提交时误加的ADD指令，不再换源，而且使用了更高效的 w2 run -M prod -D /whistle