### PR TITLE
fix:remove ADD command, using ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine
-COPY .npmrc /root/
-RUN sed -i 's/dl-cdn.alpinelinux.org/mirrors.tuna.tsinghua.edu.cn/g' /etc/apk/repositories&&apk add --no-cache nodejs npm && npm install whistle -g && apk del npm && mkdir /whistle
-CMD w2 run -M prod -D /whistle
 EXPOSE 8899
+RUN apk add --no-cache nodejs npm \
+    && npm install whistle -g \
+    && apk del npm \
+    && mkdir /whistle
+ENTRYPOINT ["w2", "run", "-M","prod", "-D","/whistle"]


### PR DESCRIPTION
删除了上次误加的 ADD 指令，在 RUN 里不再执行换源命令。将 CMD 换成了 ENTRYPOINT。

我在 DockerHub 上创建了一个自动构建的镜像，但是因为权限的问题，所以仓库用的我 fork 的仓库中的 Dockerfile。

可以使用以下命令运行：

```cmd
docker pull dragontao/whistle
docker volume create whistle_data
docker run -d -p 8899:8899 -v whistle_data:/whistle dragontao/whistle
```

pull 的时候镜像的大小是 28.03 MB，解压后是 68.7 MB。