### PR TITLE
fix: 暗色模式下，图片受滤镜影响，颜色不正确

### DIFF
--- a/biz/webui/htdocs/src/css/base.css
+++ b/biz/webui/htdocs/src/css/base.css
@@ -10,6 +10,9 @@ body,
   .w-allow-dark-mode {
     filter: invert(1) hue-rotate(-180deg);
   }
+  .w-allow-dark-mode img {
+    filter: invert(1) hue-rotate(180deg);
+  }
 }
 #container {
   min-width: 1075px; /* 兼容竖屏 */


### PR DESCRIPTION
滤镜方式实现暗色模式，图片也受到了影响，如下图所示。

<img width="542" alt="image" src="https://github.com/avwo/whistle/assets/12368943/8360adcd-3e80-46a0-b71b-0acd2aed3a34">
