### PR TITLE
fix bug: cert serial number must not negative

### DIFF
--- a/lib/https/ca.js
+++ b/lib/https/ca.js
@@ -194,6 +194,7 @@ function createSelfCert(hostname) {
       .digest('hex') +
     getIndex() +
     workerIndex;
+  serialNumber = '0' + serialNumber.slice(1);
   var cert = createCert(
     pki.setRsaPublicKey(ROOT_KEY.n, ROOT_KEY.e),
     serialNumber,


### PR DESCRIPTION
golang 1.23 这个版本不允许负数的证书编号：
```
arseCertificate parses a single certificate from the given ASN.1 DER data.

Before Go 1.23, ParseCertificate accepted certificates with negative serial numbers. This behavior can be restored by including "x509negativeserial=1" in the GODEBUG environment variable.
```
详情参考这里：https://pkg.go.dev/crypto/x509#ParseCertificate
golang官方http.Client返回错误：
Get "https://www.baidu.com/": tls: failed to parse certificate from server: x509: negative serial number

原因：whistle随机生成的序列号，有时候是负数。