### PR TITLE
fix: improve HTTP2 response handling for empty body responses

### DIFF
--- a/lib/https/h2.js
+++ b/lib/https/h2.js
@@ -297,10 +297,29 @@ function requestH2(client, req, res, callback) {
       svrRes.statusCode = statusCode;
       // HTTP2 对响应内容格式要求太严格（NGHTTP2_PROTOCOL_ERROR）
       if (!util.hasBody(svrRes, req)) {
-        h2Session.destroy();
-        svrRes = util.createTransform();
-        svrRes.statusCode = statusCode;
-        svrRes.push(null);
+        var wrapperStream = util.createTransform();
+        wrapperStream.statusCode = statusCode;
+
+        var hasReceivedData = false;
+        h2Session.on('data', function(chunk) {
+          hasReceivedData = true;
+          wrapperStream.push(chunk);
+        });
+
+        h2Session.on('end', function() {
+          if (!hasReceivedData) {
+            // 确实没有数据，正常结束
+            wrapperStream.push(null);
+          }
+          h2Session.destroy();
+        });
+
+        h2Session.on('error', function(err) {
+          wrapperStream.emit('error', err);
+          h2Session.destroy();
+        });
+
+        svrRes = wrapperStream;
       }
       svrRes.httpVersion = '1.1';
       svrRes.headers = newHeaders;


### PR DESCRIPTION
- Replace immediate session destroy with proper event handling
- Add data and end event listeners for h2Session
- Ensure wrapper stream properly handles empty responses
- Fix potential race condition in HTTP2 protocol handling