### PR TITLE
fix: restore Download button single-click (#1309)

### DIFF
--- a/biz/webui/htdocs/src/js/json-viewer.js
+++ b/biz/webui/htdocs/src/js/json-viewer.js
@@ -253,6 +253,7 @@ var JsonViewer = React.createClass({
         <div className="w-textarea-bar">
           <CopyBtn value={data.str} />
           <a
+            className="w-download"
             onDoubleClick={this.download}
             onClick={this.showNameInput}
             draggable="false"

--- a/biz/webui/htdocs/src/js/textarea.js
+++ b/biz/webui/htdocs/src/js/textarea.js
@@ -165,6 +165,7 @@ var Textarea = React.createClass({
             <CopyBtn name="AsHex" value={util.getHexText(props.value)} />
           ) : undefined}
           <a
+            className="w-download"
             onDoubleClick={this.download}
             onClick={this.showNameInput}
             draggable="false"


### PR DESCRIPTION
## Summary
- Fixes #1309 — 单击 Download 按钮无法弹出文件名输入框
- Dark mode 重构 (`0ae2073`) 意外删除了 `className="w-download"`，导致 `showNameInput` 无法识别点击来源

## Changes
- `biz/webui/htdocs/src/js/textarea.js`: 恢复 `className="w-download"`
- `biz/webui/htdocs/src/js/json-viewer.js`: 同上

## Root cause
`showNameInput` 通过 `/w-download/.test(e.target.className)` 判断是否显示文件名输入框。没有这个 class，单击 Download 会错误地显示 Key 输入框而非文件名输入框。

## Test plan
- [ ] 单击 Download → 弹出文件名输入框（而非 Key 输入框）
- [ ] 双击 Download → 直接下载（行为不变）

🤖 Generated with [Claude Code](https://claude.com/claude-code)