### PR TITLE
fix: resReplace 含 & 时, 误发 HTTP 请求导致卡顿

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -1274,7 +1274,7 @@ function readRuleList(rule, callback, isJson, charset, isHtml, req) {
     if (isJson) {
       var val = removeProtocol(getMatcher(rule), true);
       val = val && val.trim();
-      var json = getMatcherJson(rule, val) || parsePureJSON(val, QUERY_PARAM_RE.test(val));
+      var json = getMatcherJson(rule, val) || parsePureJSON(val, QUERY_PARAM_RE.test(val)) || tryParseMatcher(null, rule);
       if (json) {
         return callback(json);
       }
@@ -1351,7 +1351,7 @@ function readRuleList(rule, callback, isJson, charset, isHtml, req) {
             json = { enable: true };
           }
         }
-        json = json || parsePureJSON(value, QUERY_PARAM_RE.test(value));
+        json = json || parsePureJSON(value, QUERY_PARAM_RE.test(value)) || tryParseMatcher(null, r);
         if (json) {
           result[i] = json;
           return execCallback();


### PR DESCRIPTION
---- 人话 ----
我这段时间在做一个基于vscode web版本的项目，dev模式下，每次都要加载7000+个文件。对应的 whistle 规则里面，我用了 

```
gamemaker.weixin.qq.com resReplace://http://gamemaker.weixin.qq.com=https://gamemaker.weixin.qq.com&http://{{uuid}}.gamemaker.weixin.qq.com=https://{{uuid}}.gamemaker.weixin.qq.com
```

这样一句。一开始也没觉得有什么不对。直到今早上，帮别人排查一个sse的问题（其实在这个bug场景中，sse是个干扰项），结果对应的response总是迟到20+s才返回，我就拉着后台和运维同事和测试组的同事折腾了一早上。结果他们发现，用shell的curl来重现问题，就无法重现，只有我的浏览器有问题。

我百思不得其解，不甘心查了一下午，发现原来是whistle的这个 resReplace 的解析方式有问题。


---- ai commit message ----
getMatcherJson 遇到值中 = 后有 & 会跳过解析，导致 readRuleValue
将 http:// 开头的 matcher 当作 URL 发起请求，超时约 16s。
在 readRuleValue 之前增加 tryParseMatcher fallback 即可避免。



---- ai pr message ----

这是我跟cursor用debug mode查了一下午，总结历史而成的pr message。我自测这个fix是没问题的，但是否修在了精准的地方，还得您来判断。

```markdown
## **resReplace 含 `&` 分隔多组替换时，响应卡顿 15-30 秒**

### **问题**

使用 `resReplace` 配置多组替换（用 `&` 分隔 key=value 对）时，例如：

pattern resReplace://http://a.com=https://a.com&http://b.com=https/://b.com

每个匹配到的响应都会卡顿约 16-32 秒。在大量文件并发加载的场景（如 VS Code Web 初始化 7000+ 文件）下，页面几乎不可用。

### **原因**

`readRuleList` 解析规则值时依次调用 `getMatcherJson` → `parsePureJSON`，均失败后 fallback 到 `readRuleValue`。

- `getMatcherJson`：发现 `=` 后面存在 `&`，误判为 query string 格式，直接 return
- `parsePureJSON`：值不是合法 JSON，解析失败
- `readRuleValue` → `resolveKey`：值以 `http://` 开头，被当作远程 URL 发起 HTTP 请求
- 目标路径无效（如 `http://a.com/=https://a.com&...`），等待 16 秒超时后自动重试，合计约 32 秒

超时返回空值后，`tryParseMatcher` 作为 post-hoc fallback 用 `parseQuery` 成功解析——**替换功能正常，但白白等了一个超时周期**。

### **修复**

在 `readRuleValue` 之前增加 `tryParseMatcher(null, rule)` 作为第三级 fallback。该函数用 `parseQuery` 按 `&` 分割 key=value，本身已作为 `readRuleValue` 返回后的兜底逻辑存在，只是调用时机太晚。提前到 inline 解析阶段即可避免无意义的 HTTP 请求。

```
