### PR TITLE
docs: fix Rewrite Response typo

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -135,7 +135,7 @@ export default defineConfig({
                 ]
               },
               {
-                text: 'Rewrite Reponse',
+                text: 'Rewrite Response',
                 collapsed: false,
                 items: [
                   { text: 'statusCode', link: '/en/docs/rules/statusCode' },
@@ -347,7 +347,7 @@ export default defineConfig({
             ]
           },
           {
-            text: 'Rewrite Reponse',
+            text: 'Rewrite Response',
             collapsed: false,
             items: [
               { text: 'statusCode', link: '/docs/rules/statusCode' },

--- a/docs/docs/rules/protocols.md
+++ b/docs/docs/rules/protocols.md
@@ -57,7 +57,7 @@
 24. [reqRules](./reqRules)
 25. [reqScript](./reqScript)
 
-## Rewrite Reponse（修改响应数据）
+## Rewrite Response（修改响应数据）
 1. [statusCode](./statusCode)
 2. [replaceStatus](./replaceStatus)
 3. [redirect](./redirect)


### PR DESCRIPTION
Fixes #1327

Changes:
- Corrects `Rewrite Reponse` to `Rewrite Response` in the docs navigation/config and protocols heading.

Verification:
- Confirmed the exact typo existed in the current upstream branch.
- Ran `git diff --check`.
- Confirmed `Rewrite Reponse` no longer appears in the touched files.