### PR TITLE
fix: keep custom parser tunnel context

### DIFF
--- a/lib/socket-mgr.js
+++ b/lib/socket-mgr.js
@@ -800,7 +800,7 @@ exports.handleConnect = function (req, res, isUpgrade) {
         }
         if (hideFrame && !frameCtx) {
           reqTrans._transform = resTrans._transform = handleTransform;
-          options.ctx = false;
+          options.ctx = customParser && !hide ? getContext(req, res, hasEvent, sendStatus, receiveStatus) : false;
         } else {
           req.wsExts = res.wsExts = reqTrans.wsExts = resTrans.wsExts = '';
           if (reqWrite) {

--- a/test/units/customParser.test.js
+++ b/test/units/customParser.test.js
@@ -1,0 +1,42 @@
+var stream = require('stream');
+var config = require('../../lib/config');
+var pluginMgr = require('../../lib/plugins');
+var socketMgr = require('../../lib/socket-mgr');
+
+module.exports = function() {
+  var oldCaptureData = config.captureData;
+  var oldGetTunnelPipe = pluginMgr.getTunnelPipe;
+  var reqId = 'custom-parser-tunnel-test';
+  var req = new stream.PassThrough();
+  var res = new stream.PassThrough();
+  var proxy = {
+    emit: function() {}
+  };
+
+  config.captureData = true;
+  socketMgr(proxy);
+  req.reqId = reqId;
+  req.fullUrl = 'tunnel://custom.parser.test:1234';
+  req.headers = {};
+  req.enable = {};
+  req.disable = {};
+  req.rules = {};
+  req.customParser = true;
+  req.inspectFrames = true;
+  req.isPluginReq = false;
+  res.headers = req.headers;
+  pluginMgr.getTunnelPipe = function(req, res, callback) {
+    callback();
+  };
+
+  try {
+    socketMgr.setPending(req);
+    socketMgr.handleConnect(req, res, false);
+    var data = socketMgr.getData(reqId);
+    data.should.be.an.Object();
+  } finally {
+    socketMgr.destroy(reqId);
+    pluginMgr.getTunnelPipe = oldGetTunnelPipe;
+    config.captureData = oldCaptureData;
+  }
+};


### PR DESCRIPTION
### 问题

  在引入 `frameScript` 后，`enable://customParser` 的 TCP tunnel 在没有有效 `frameScript://` 时会进入 `hideFrame && !frameCtx` 分支。

  此时 `removePending(reqId)` 已经被调用，但没有创建 socket context：

  ```js
  if (hideFrame && !frameCtx) {
    reqTrans._transform = resTrans._transform = handleTransform;
    options.ctx = false;
  }

  这样会导致后续：

  socketMgr.getData(reqId)

  返回 undefined。

  插件侧 custom parser 的轮询逻辑会把空结果视为连接已断开，并执行：

  conn.destroy()

  因此，一个仍然活跃的 customParser tunnel 可能会被误关闭。

  ### 修复

  对于 customParser TCP tunnel，即使没有 frameScript context，也保留创建 socket context，同时仍然使用透明 transform。

  这样可以恢复之前的行为：

  - customParser tunnel 有对应的 socket context；
  - 没有配置 frameScript 时不会做 frame 转换；
  - 已有的 frameScript 功能不受影响。

  ### 测试

  新增了一个最小单测，模拟一个没有 frameScript 的 customParser tunnel：

  1. 将请求标记为 pending；
  2. 调用 handleConnect；
  3. 验证 socketMgr.getData(reqId) 返回对象，而不是 undefined。

  该测试在修复前会失败，修复后通过。

  本地测试命令：

  WHISTLE_PATH=/tmp/whistle-pr-custom-parser-ctx/test node -e "require('should'); require('./test/units/customParser.test')(); process.exit(0)"

