### PR TITLE
fix: correct typo in access-control-allow-methods header name

### DIFF
--- a/lib/util/index.js
+++ b/lib/util/index.js
@@ -2977,7 +2977,7 @@ exports.setResCors = function (data, cors, req) {
   } else if (autoComp) {
     var method = req.headers['access-control-request-method'];
     if (method) {
-      setHeader(data, 'access-control-allow-method', method);
+      setHeader(data, 'access-control-allow-methods', method);
     }
   }
 


### PR DESCRIPTION
The autoComp branch in setResCors was setting 'access-control-allow-method' (singular) instead of 'access-control-allow-methods' (plural). This caused browsers to reject preflight OPTIONS responses when using resCors://enable, as they only recognize the plural form per the WHATWG Fetch Standard.

WHATWG Fetch Standard: https://fetch.spec.whatwg.org/
W3C CORS (Superseded): https://www.w3.org/TR/2020/SPSD-cors-20200602/
MDN: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Methods