### PR TITLE
fix: upgrade adm-zip to 0.6.0 (CVE-2026-39244)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.10.7",
       "license": "MIT",
       "dependencies": {
-        "adm-zip": "0.5.16",
+        "adm-zip": "^0.6.0",
         "async-limiter": "2.0.0",
         "body-parser": "^1.20.3",
         "colors": "1.1.2",
@@ -1499,11 +1499,12 @@
       }
     },
     "node_modules/adm-zip": {
-      "version": "0.5.16",
-      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==",
+      "license": "MIT",
       "engines": {
-        "node": ">=12.0"
+        "node": ">=14.0"
       }
     },
     "node_modules/ajv": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "url": "https://github.com/avwo/whistle.git"
   },
   "dependencies": {
-    "adm-zip": "0.5.16",
+    "adm-zip": "^0.6.0",
     "async-limiter": "2.0.0",
     "body-parser": "^1.20.3",
     "colors": "1.1.2",


### PR DESCRIPTION
## Summary
Upgrade adm-zip from 0.5.16 to 0.6.0 to fix CVE-2026-39244.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-39244 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-39244` |
| **File** | `package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: adm-zip: adm-zip: Denial of Service via crafted ZIP file leading to excessive memory allocation

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-39244` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a web service - vulnerabilities in request handlers are directly exploitable by remote attackers.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
