### PR TITLE
fix: plugin custom inspector tab hidden by display:none

### DIFF
--- a/biz/webui/htdocs/src/js/tab-mgr.js
+++ b/biz/webui/htdocs/src/js/tab-mgr.js
@@ -57,6 +57,23 @@ var TabMgr = React.createClass({
     var hide = props.hide;
     var active = props.active;
     var hideAll = true;
+    var tabs = props.tabs.map(function (tab) {
+      var plugin = tab.plugin;
+      var hideTab = hide || active !== plugin;
+      if (!hideTab) {
+        hideAll = false;
+      }
+      return (
+        self.isInited(tab) && (
+          <TabFrame
+            ref={plugin}
+            key={plugin}
+            src={tab.action}
+            hide={hideTab}
+          />
+        )
+      );
+    });
     return (
       <div
         className={
@@ -65,23 +82,7 @@ var TabMgr = React.createClass({
           util.getHide(hideAll)
         }
       >
-        {props.tabs.map(function (tab) {
-          var plugin = tab.plugin;
-          var hideTab = hide || active !== plugin;
-          if (!hideTab) {
-            hideAll = false;
-          }
-          return (
-            self.isInited(tab) && (
-              <TabFrame
-                ref={plugin}
-                key={plugin}
-                src={tab.action}
-                hide={hideTab}
-              />
-            )
-          );
-        })}
+        {tabs}
       </div>
     );
   }


### PR DESCRIPTION
## Summary

Fixes a regression where plugin custom inspector tabs (declared via `whistleConfig.inspectorsTab`) render but stay invisible, showing a blank body when clicked.

## Root cause

In `TabMgr.render()`, the container div's `className` — which includes `util.getHide(hideAll)` — was evaluated **before** `props.tabs.map()` ran. At that point `hideAll` still held its initial value `true`, so `getHide(true)` always returned `" hide"` and the container permanently carried the `hide` class (`display:none`).

This was introduced in 2.10.8 when the 2.10.7 two-step logic (map first, then `getHide` with the corrected flag) was merged into a single expression, so the `s = !1` correction in the `map()` callback ran too late.

## Fix

Hoist the `map()` call into a local variable so the `hideAll` flag is corrected **before** `getHide()` is evaluated, restoring 2.10.7 semantics.

```js
var tabs = props.tabs.map(function (tab) {
  var hideTab = hide || active !== tab.plugin;
  if (!hideTab) {
    hideAll = false;
  }
  // ...
});
return (
  <div className={'fill v-box ' + (props.className || '') + util.getHide(hideAll)}>
    {tabs}
  </div>
);
```

## Impact

- Built-in tabs (Raw/Headers/Preview/Body/JSONView/HexView/Cookies/Trailers) are unaffected — they don't go through `TabMgr`.
- All plugin custom tabs (req/res) were affected on 2.10.8+.

## Verification

- `eslint` passes.
- Rebuilt the webui bundle; the minified `TabMgr.render` now evaluates `getHide(s)` after the `map()` callback corrects `s`.
- Before: container rendered as `class="fill v-box hide"` (iframe `offsetWidth/offsetHeight` = 0). After: `class="fill v-box"` with normal dimensions.