### PR TITLE
fix: 不再复用已关闭的 H2 session；插件 pipe 等出站缓冲刷完后再断开

### DIFF
--- a/lib/https/h2.js
+++ b/lib/https/h2.js
@@ -256,7 +256,7 @@ function getClient(req, socket, name, callback) {
   return client;
 }
 
-function requestH2(client, req, res, callback) {
+function requestH2(client, req, res, callback, clientName) {
   if (req._hasError) {
     return;
   }
@@ -268,6 +268,13 @@ function requestH2(client, req, res, callback) {
   delete req.headers['transfer-encoding'];
   var options = req.options;
   var responsed;
+  var callbacked;
+  var fallback = function() {
+    if (!callbacked) {
+      callbacked = true;
+      callback();
+    }
+  };
   headers[':path'] = options.path;
   headers[':method'] = options.method;
   headers[':authority'] = req.headers.host;
@@ -276,8 +283,11 @@ function requestH2(client, req, res, callback) {
     onClose(h2Session, function() {
       if (!responsed) {
         responsed = true;
+        if ((client.closed || client.destroyed) && clientName && clients[clientName] === client) {
+          delete clients[clientName];
+        }
         h2Session.destroy();
-        req.noReqBody && callback();
+        req.noReqBody && fallback();
       }
     });
     var additionalHeaders;
@@ -327,8 +337,13 @@ function requestH2(client, req, res, callback) {
     });
     req.pipe(h2Session);
   } catch (e) {
-    !responsed && callback();
-    responsed = true;
+    if (!responsed) {
+      responsed = true;
+      if ((client.closed || client.destroyed) && clientName && clients[clientName] === client) {
+        delete clients[clientName];
+      }
+      fallback();
+    }
   }
 }
 
@@ -389,6 +404,12 @@ exports.request = function (req, res, callback) {
   var reqId = req.disable.keepH2Session ? '' : req._h2ReqId;
   var name = (reqId || req.clientIp) + '\n' + key;
   var client = clients[name];
+  if (client && (client.closed || client.destroyed)) {
+    if (clients[name] === client) {
+      delete clients[name];
+    }
+    client = null;
+  }
   if (client) {
     if (!reqId) {
       if (client.curIndex) {
@@ -398,10 +419,16 @@ exports.request = function (req, res, callback) {
       } else {
         client.curIndex = 1;
       }
+      if (client && (client.closed || client.destroyed)) {
+        if (clients[name] === client) {
+          delete clients[name];
+        }
+        client = null;
+      }
     }
     if (client) {
       client._updateTime = Date.now();
-      return requestH2(client, req, res, callback);
+      return requestH2(client, req, res, callback, name);
     }
   }
   var time = notH2.peek(key);
@@ -434,7 +461,7 @@ exports.request = function (req, res, callback) {
         if (clt) {
           notH2.del(key);
           pendingItem.forEach(function (list) {
-            requestH2(clt, list[0], list[1], list[2]);
+            requestH2(clt, list[0], list[1], list[2], name);
           });
         } else {
           checkTlsError(err) && notH2.set(key, Date.now());

--- a/lib/plugins/load-plugin.js
+++ b/lib/plugins/load-plugin.js
@@ -66,6 +66,7 @@ var framesCallbacks = [];
 var MAX_LENGTH = 100;
 var MAX_BUF_LEN = 1024 * 1024;
 var TIMEOUT = 300;
+var PIPE_FLUSH_TIMEOUT = 1000 * 30;
 var REQ_INTERVAL = 16;
 var pluginOpts, storage, sharedStorage;
 var MASK_OPTIONS = { mask: true };
@@ -1109,10 +1110,6 @@ function handleWsSignal(receiver, sender) {
   receiver.onclose = function (code, message, opts) {
     sender.close(code, message, opts.masked);
   };
-}
-
-function destroySocket() {
-  this.destroy();
 }
 
 function formatRules(rules) {
@@ -2359,8 +2356,27 @@ module.exports = async function (options, callback) {
             var decoder = getDecodeTransform();
             var encoder = getEncodeTransform();
             var done;
+            var inputEnded;
+            var outputEnded;
+            var encoderFinished;
+            var flushTimer;
+            var endSocket = function () {
+              if (outputEnded || socket.destroyed) {
+                return;
+              }
+              outputEnded = true;
+              if (flushTimer) {
+                clearTimeout(flushTimer);
+                flushTimer = null;
+              }
+              socket.end();
+            };
             var handleError = function (err) {
               if (!done) {
+                if (flushTimer) {
+                  clearTimeout(flushTimer);
+                  flushTimer = null;
+                }
                 done = true;
                 socket.emit('error', err || new Error('destroyed'));
               }
@@ -2373,9 +2389,17 @@ module.exports = async function (options, callback) {
               }
             });
             encoder.once('finish', function () {
+              encoderFinished = true;
               done = true;
+              if (inputEnded) {
+                endSocket();
+              }
             });
             socket.on('close', function () {
+              if (flushTimer) {
+                clearTimeout(flushTimer);
+                flushTimer = null;
+              }
               done = true;
               decoder.emit('close');
               encoder.emit('close');
@@ -2388,7 +2412,18 @@ module.exports = async function (options, callback) {
             });
             socket.pipe(decoder);
             encoder.pipe(socket);
-            socket.on('end', destroySocket);
+            socket.on('end', function () {
+              inputEnded = true;
+              if (encoderFinished) {
+                return endSocket();
+              }
+              flushTimer = setTimeout(function () {
+                flushTimer = null;
+                if (!encoderFinished && !socket.destroyed) {
+                  socket.destroy();
+                }
+              }, PIPE_FLUSH_TIMEOUT);
+            });
             httpServer.emit('request', decoder, encoder);
           });
         }


### PR DESCRIPTION
## 问题

这个 PR 包含两处相关修复：

1. **`lib/https/h2.js`：HTTP/2 session 缓存会命中已经关闭的 session**。session 被对端 GOAWAY、idle timeout 或 whistle 自身的 60s 清理关掉后仍留在 `clients` 缓存里，后续请求直接在其上开 stream，遇到同步 throw 或异步 `ERR_HTTP2_INVALID_SESSION`。**这个问题与是否加载 pipe 插件无关**，不启用插件时的表现是该跳请求失败或被内部吃掉；
2. **`lib/plugins/load-plugin.js`：插件 pipe 在入站 EOF 时立即销毁 socket**。上面第 1 点的失败一旦发生，`_closed` 会连带拆掉本次请求上还在途的两条插件 CONNECT（reqRead/reqWrite），客户端观察到的就是**偶发 POST 长时间无响应直到超时**——即实际使用中最先暴露出的症状，是第 1 点被 pipe 放大后的表现形式。

两者一起修才能同时解决「根因」和「最先看到的症状」。

## 场景

| 角色 | 是谁 |
|---|---|
| 客户端 | App / 浏览器 |
| whistle 本体 | 代理，决定转发与 HTTP/2 复用 |
| 插件 | 通过 pipe 机制处理请求/响应 body |
| 服务端 | 真实 HTTPS 接口 |

请求方向被 whistle 拆成两次 localhost CONNECT：

```
客户端
  → whistle
  → CONNECT 插件 reqRead（插件读完请求 body 后写回）
  → whistle
  → CONNECT 插件 reqWrite（插件再写回给 whistle）
  → whistle 用缓存的 HTTP/2 session 向服务端开 stream
  → 服务端
```

whistle **不会等 reqWrite 连上再让 reqRead 结束**。小 POST 几毫秒就写完，reqWrite 握手往往还没完。

## 根因一（主修）：`lib/https/h2.js` 复用前未检查 session 是否已关闭

`clients[name]` 按「客户端 IP + 主机」缓存 `Http2Session`，后续请求直接 `client.request()`。

复用前**不检查** `closed` / `destroyed`。session 已死但仍留在 cache 时，再 `request()` 会走到两种失败之一：

- 同步 throw：`requestH2` 的 try/catch 接到，`callback()` 回退 HTTP/1.1（相对安全）
- 异步 error（实测主要路径）：`ERR_HTTP2_INVALID_SESSION` 经由该次请求的错误处理触发 abort 流程，最终 `_closed`

两种失败都会置位本次请求的失败状态：带 body 的请求既得不到 HTTP/1.1 回退也得不到响应。在没有加载插件时表现为一次失败的请求；一旦加载了 pipe 插件，`_closed` 拆链的行为就变成上文所说的长时间无响应。

对照：Web UI 取消勾选 **Enable HTTP/2** 后走 HTTP/1.1，不再复用这条 session，问题不再出现。

## 根因二（次要）：`lib/plugins/load-plugin.js` 的 pipe 出站缓冲被截断

`emitHttpPipe()` 中 `socket.on('end', destroySocket)`：插件在同一轮 `end` 里写完 body + 终止帧时，出站缓冲可能还没刷完，`destroy()` 会 RST，对端永远收不到数据。

## 本 PR 改动

### 1. `lib/https/h2.js`（主修）

- 缓存命中后先检查 `client.closed || client.destroyed`（覆盖基础 key 与 `curIndex` 并发槽位两条命中路径），命中陈旧条目时以对象身份保护删除，走新建连接或 HTTP/1.1，不进入 `requestH2`；
- `requestH2` 内对「响应前」的流级失败做幂等处理：session 已死则删除缓存条目并 `destroy()` 流；`req.noReqBody` 时走既有 HTTP/1.1 回退。同步 throw 的既有 try/catch 回退语义不变；
- 刻意不做自动重放：带 body 的请求即使流失败也不回退 HTTP/1.1，避免部分写出后的非幂等双提交。

### 2. `lib/plugins/load-plugin.js`（次要）

`emitHttpPipe()` 里改掉 `socket.on('end', destroySocket)`：改为等 encoder flush 完成后再 `socket.end()`（半关闭），不再立刻 `destroy()`；另加 30s 兜底超时防止异常插件永久占住连接。

## 建议验证

1. 打开 Enable HTTP/2（如需复现原症状，配置插件 pipe；仅验证根因修复可不配）
2. 重复小 POST（有 body 的短请求）
3. 人为或等待 H2 session 被对端关掉后立刻再发
4. 期望：该次请求回退新建连接 / HTTP/1.1 并完成，而不是失败或长时间转圈；不应再出现异步 H2 错误触发 `_closed` 拆掉 reqRead/reqWrite 的情形
